### PR TITLE
Add resume to about page.

### DIFF
--- a/source/about.html.md.erb
+++ b/source/about.html.md.erb
@@ -22,5 +22,9 @@ Some of my interests include:
 - Listening, creating and performing music.
 - Ideas: Products and businesses, a user's experience, technical solutions.
 
+If you'd like, you can
+<%= link_to 'read my Resume', '/rhcvweb.pdf' %>
+for my most recent experiences in the job world.
+
 <%= image_tag "images/wffampic.jpg", class: "img-responsive" %>
 


### PR DESCRIPTION
I did this because the resume link in the footer might get missed over time.
People might expect to read about my work experience in the about section of
the site.